### PR TITLE
exarepo_tasks supports .csv, .json files, multiple flies

### DIFF
--- a/lib/wax_tasks/asset.rb
+++ b/lib/wax_tasks/asset.rb
@@ -56,7 +56,7 @@ module WaxTasks
         if nrow > total_rows
           warn Rainbow("Tried to create derivative #{nrow} rows long, but asset #{@id} for item #{@pid} only has #{total_rows} rows.").yellow
         else
-          my_output = my_output[0, nrow + 1]
+          my_output = my_output[0, nrow]
          end
 
         preview_data = my_output

--- a/lib/wax_tasks/asset.rb
+++ b/lib/wax_tasks/asset.rb
@@ -46,10 +46,11 @@ module WaxTasks
         # get total rows
         csv_file = File.open(@path,"rb")
         #total_rows = csv_file.readlines.size
-        total_rows = `wc -l < #{@path}`.to_i
         data = CSV.read(@path, { encoding: "r:bom|utf-8", headers: true, converters: :all})
         hashed_data = data.map { |d| d.to_hash }
         my_output = hashed_data
+
+        total_rows = my_output.length
 
         if nrow > total_rows
           warn Rainbow("Tried to create derivative #{nrow} rows long, but asset #{@id} for item #{@pid} only has #{total_rows} rows.").yellow

--- a/lib/wax_tasks/asset.rb
+++ b/lib/wax_tasks/asset.rb
@@ -44,15 +44,23 @@ module WaxTasks
     def simple_file_derivatives
       @variants.map do |label, nrow|
         # get total rows
-        csv_file = File.open(@path,"r")
+        csv_file = File.open(@path,"rb")
         #total_rows = csv_file.readlines.size
         total_rows = `wc -l < #{@path}`.to_i
+        puts nrow
+        puts total_rows
+        my_output = Array.new
+        my_output << CSV.open(@path, 'r') { |csv| csv.first }
+        CSV.foreach(@path, headers: true) do |row|
+          my_output << row
+        end
         if nrow > total_rows
           warn Rainbow("Tried to create derivative #{nrow} rows long, but asset #{@id} for item #{@pid} only has #{total_rows} rows.").yellow
-          csv_preview = csv_file
         else
-          csv_preview = CSV.foreach(@path, headers: true).take(nrow)
-        end
+          my_output = my_output[0, nrow + 1]
+         end
+        
+        csv_preview = my_output
 
         FileDerivative.new("#{@id}/#{label}.csv", label, csv_preview)
       end

--- a/lib/wax_tasks/asset.rb
+++ b/lib/wax_tasks/asset.rb
@@ -43,10 +43,11 @@ module WaxTasks
 
     def simple_file_derivatives
       @variants.map do |label, nrow|
-        # get total rows
-        csv_file = File.open(@path,"rb")
-        #total_rows = csv_file.readlines.size
-        data = CSV.read(@path, { encoding: "r:bom|utf-8", headers: true, converters: :all})
+
+        # TODO: isolate file parsing in function
+        # (to handle at least CSV and JSON, handle parsing errors)
+        
+        data = CSV.read(@path, { encoding: "bom|utf-8", headers: true, converters: :all})
         hashed_data = data.map { |d| d.to_hash }
         my_output = hashed_data
 
@@ -59,12 +60,12 @@ module WaxTasks
          end
         
         puts my_output
-        csv_preview = my_output
+        preview_data = my_output
 
         size = (File.size(@path).to_f / 2**20).round(5)
         puts "Successfully generated preview for csv file: #{size} MB, #{total_rows} rows (#{nrow} used)"
 
-        FileDerivative.new("#{@id}/#{label}.csv", label, csv_preview, size)
+        FileDerivative.new("#{@id}/#{label}.json", label, preview_data, size)
       end
     end
 

--- a/lib/wax_tasks/asset.rb
+++ b/lib/wax_tasks/asset.rb
@@ -47,17 +47,17 @@ module WaxTasks
         csv_file = File.open(@path,"rb")
         #total_rows = csv_file.readlines.size
         total_rows = `wc -l < #{@path}`.to_i
-        my_output = Array.new
-        my_output << CSV.open(@path, &:readline)
-        CSV.foreach(@path, headers: true) do |row|
-          my_output << row
-        end
+        data = CSV.read(@path, { encoding: "r:bom|utf-8", headers: true, converters: :all})
+        hashed_data = data.map { |d| d.to_hash }
+        my_output = hashed_data
+
         if nrow > total_rows
           warn Rainbow("Tried to create derivative #{nrow} rows long, but asset #{@id} for item #{@pid} only has #{total_rows} rows.").yellow
         else
           my_output = my_output[0, nrow + 1]
          end
         
+        puts my_output
         csv_preview = my_output
 
         size = (File.size(@path).to_f / 2**20).round(5)

--- a/lib/wax_tasks/asset.rb
+++ b/lib/wax_tasks/asset.rb
@@ -5,7 +5,7 @@ require 'csv'
 #
 module WaxTasks
   Derivative = Struct.new(:path, :label, :img)
-  FileDerivative = Struct.new(:path, :label, :csv_preview)
+  FileDerivative = Struct.new(:path, :label, :csv_preview, :size)
   #
   class Asset
     attr_reader :id, :path
@@ -47,10 +47,8 @@ module WaxTasks
         csv_file = File.open(@path,"rb")
         #total_rows = csv_file.readlines.size
         total_rows = `wc -l < #{@path}`.to_i
-        puts nrow
-        puts total_rows
         my_output = Array.new
-        my_output << CSV.open(@path, 'r') { |csv| csv.first }
+        my_output << CSV.open(@path, &:readline)
         CSV.foreach(@path, headers: true) do |row|
           my_output << row
         end
@@ -62,7 +60,10 @@ module WaxTasks
         
         csv_preview = my_output
 
-        FileDerivative.new("#{@id}/#{label}.csv", label, csv_preview)
+        size = (File.size(@path).to_f / 2**20).round(5)
+        puts "Successfully generated preview for csv file: #{size} MB, #{total_rows} rows (#{nrow} used)"
+
+        FileDerivative.new("#{@id}/#{label}.csv", label, csv_preview, size)
       end
     end
 

--- a/lib/wax_tasks/asset.rb
+++ b/lib/wax_tasks/asset.rb
@@ -5,7 +5,7 @@ require 'csv'
 #
 module WaxTasks
   Derivative = Struct.new(:path, :label, :img)
-  FileDerivative = Struct.new(:path, :label, :csv_preview, :size)
+  FileDerivative = Struct.new(:path, :label, :preview_data, :size)
   #
   class Asset
     attr_reader :id, :path
@@ -58,8 +58,7 @@ module WaxTasks
         else
           my_output = my_output[0, nrow + 1]
          end
-        
-        puts my_output
+
         preview_data = my_output
 
         size = (File.size(@path).to_f / 2**20).round(5)

--- a/lib/wax_tasks/collection.rb
+++ b/lib/wax_tasks/collection.rb
@@ -19,7 +19,7 @@ module WaxTasks
     IMAGE_DERIVATIVE_DIRECTORY = 'img/derivatives'
     FILE_DERIVATIVE_DIRECTORY = 'files/derivatives'
     DEFAULT_VARIANTS = { 'thumbnail' => 250, 'fullwidth' => 1140 }.freeze
-    DEFAULT_FILE_VARIANTS = { 'preview' => 10 }.freeze
+    DEFAULT_FILE_VARIANTS = { 'data_preview' => 10 }.freeze
     # specifies number of rows in preview dataset
 
     #

--- a/lib/wax_tasks/collection/files.rb
+++ b/lib/wax_tasks/collection/files.rb
@@ -57,10 +57,14 @@ module WaxTasks
             next if File.exist? path
 
             # TODO: fix missing header, string quotations, extra line in csv fileout
-            CSV.open(path, "wb") do |csv|
-              d.csv_preview.each do |row|
-                csv << row
-              end
+            File.open(path, "wb") do |f|
+              f.write(d.csv_preview.to_json)
+              
+              #d.csv_preview.each do |row|
+               # puts "running? running?"
+                # puts row.to_json
+                # csv << row
+              # end
             end
 
             # d.csv_preview.write path

--- a/lib/wax_tasks/collection/files.rb
+++ b/lib/wax_tasks/collection/files.rb
@@ -52,6 +52,9 @@ module WaxTasks
         bar.write
         items_from_filedata.map do |item|
           item.simple_file_derivatives.each do |d| # these are valid assets
+            # skip if empty preview
+            next if d.preview_data == []
+            
             path = "#{@simple_file_derivative_source}/#{d.path}"
             FileUtils.mkdir_p File.dirname(path)
             next if File.exist? path

--- a/lib/wax_tasks/collection/files.rb
+++ b/lib/wax_tasks/collection/files.rb
@@ -56,10 +56,11 @@ module WaxTasks
             FileUtils.mkdir_p File.dirname(path)
             next if File.exist? path
 
-            puts path
             # TODO: fix missing header, string quotations, extra line in csv fileout
-            CSV.open(path, "w") do |csv|
-              csv << d.csv_preview
+            CSV.open(path, "wb") do |csv|
+              d.csv_preview.each do |row|
+                csv << row
+              end
             end
 
             # d.csv_preview.write path

--- a/lib/wax_tasks/collection/files.rb
+++ b/lib/wax_tasks/collection/files.rb
@@ -58,7 +58,7 @@ module WaxTasks
 
             # TODO: fix missing header, string quotations, extra line in csv fileout
             File.open(path, "wb") do |f|
-              f.write(d.csv_preview.to_json)
+              f.write(d.preview_data.to_json)
               
               #d.csv_preview.each do |row|
                # puts "running? running?"

--- a/lib/wax_tasks/collection/files.rb
+++ b/lib/wax_tasks/collection/files.rb
@@ -20,7 +20,7 @@ module WaxTasks
         Dir.glob(Utils.safe_join(@filedata_source, '*')).map do |path|
           item = WaxTasks::Item.new(path, @file_variants)
           #next if item.type == '.pdf'
-          next puts Rainbow("Skipping #{path} because type #{item.type} is not an accepted format").yellow unless item.file_valid?
+          next puts Rainbow("Skipping #{path} because type #{item.type} is not an accepted format").yellow unless item.valid?("data")
 
           item.record      = records.find { |r| r.pid == item.pid }
           #item.iiif_config = @config.dig 'images', 'iiif'

--- a/lib/wax_tasks/collection/files.rb
+++ b/lib/wax_tasks/collection/files.rb
@@ -3,7 +3,7 @@
 #require 'mini_magick'
 require 'progress_bar'
 #require 'wax_iiif'
-
+require 'csv'
 #
 module WaxTasks
   #
@@ -56,7 +56,15 @@ module WaxTasks
             FileUtils.mkdir_p File.dirname(path)
             next if File.exist? path
 
-            d.csv_preview.write path
+            puts path
+            # TODO: fix missing header, string quotations, extra line in csv fileout
+            CSV.open(path, "w") do |csv|
+              csv << d.csv_preview
+            end
+
+            # d.csv_preview.write path
+            # expected behavior: write a truncated dataset to a new directory called files derivatives
+
             item.record.set d.label, path if item.record? # take name of variant and write asset path to record metadata
           end
           bar.increment!

--- a/lib/wax_tasks/collection/images.rb
+++ b/lib/wax_tasks/collection/images.rb
@@ -20,7 +20,7 @@ module WaxTasks
         Dir.glob(Utils.safe_join(@imagedata_source, '*')).map do |path|
           item = WaxTasks::Item.new(path, @image_variants)
           next if item.type == '.pdf'
-          next puts Rainbow("Skipping #{path} because type #{item.type} is not an accepted format").yellow unless item.valid?
+          next puts Rainbow("Skipping #{path} because type #{item.type} is not an accepted format").yellow unless item.valid?("image")
 
           item.record      = records.find { |r| r.pid == item.pid }
           item.iiif_config = @config.dig 'images', 'iiif'

--- a/lib/wax_tasks/item.rb
+++ b/lib/wax_tasks/item.rb
@@ -19,15 +19,11 @@ module WaxTasks
 
     #
     #
-    def accepted_image_formats
-      %w[.png .jpg .jpeg .tiff .tif]
+    def accepted_formats
+      { "image" => %w[.png .jpg .jpeg .tiff .tif],
+      "data" => %w[.csv .json] }
     end
 
-    #
-    #
-    def accepted_data_formats
-      %w[.csv]
-    end
 
     #
     #
@@ -38,15 +34,11 @@ module WaxTasks
 
     #
     #
-    def valid?
-      accepted_image_formats.include? @type or @type == 'dir'
+    def valid?(asset_type)
+      accepted_formats[asset_type].include? @type or @type == 'dir'
     end
 
-    #
-    #
-    def file_valid?
-      accepted_data_formats.include? @type or @type == 'dir'
-    end
+
     #
     #
     def record?
@@ -56,12 +48,12 @@ module WaxTasks
     #
     #
     def assets
-      if accepted_image_formats.include? @type
+      if accepted_formats["image"].include? @type
         [Asset.new(@path, @pid, @variants)]
-      elsif  accepted_data_formats.include? @type
+      elsif  accepted_formats["data"].include? @type
         [Asset.new(@path, @pid, @variants)]
       elsif @type == 'dir'
-        paths = Dir.glob("#{@path}/*{#{accepted_image_formats.join(',')}}").sort
+        paths = Dir.glob("#{@path}/*{#{(accepted_formats["image"] + accepted_formats["data"]).join(',')}}").sort
         paths.map { |p| Asset.new(p, @pid, @variants) }
       else
         []

--- a/lib/wax_tasks/item.rb
+++ b/lib/wax_tasks/item.rb
@@ -49,12 +49,12 @@ module WaxTasks
     #
     def assets
       if accepted_formats["image"].include? @type
-        [Asset.new(@path, @pid, @variants)]
+        [Asset.new(@path, @pid, @variants, @type)]
       elsif  accepted_formats["data"].include? @type
-        [Asset.new(@path, @pid, @variants)]
+        [Asset.new(@path, @pid, @variants, @type)]
       elsif @type == 'dir'
         paths = Dir.glob("#{@path}/*{#{(accepted_formats["image"] + accepted_formats["data"]).join(',')}}").sort
-        paths.map { |p| Asset.new(p, @pid, @variants) }
+        paths.map { |p| Asset.new(p, @pid, @variants, @type) }
       else
         []
       end

--- a/lib/wax_tasks/site.rb
+++ b/lib/wax_tasks/site.rb
@@ -96,8 +96,10 @@ module WaxTasks
                   collection.write_simple_file_derivatives
                 end
 
-      collection.update_metadata records
-      puts Rainbow("\nDone ✔").green
+      if records != []
+        collection.update_metadata records
+        puts Rainbow("\nDone ✔").green
+      end
     end
   end
 end


### PR DESCRIPTION
# Summary

Added .csv and .json support with new design to support future data types! Outputs derivative with 10 rows as desired.

# Test script

Below is the shell script I used to test `datasets` support. Note that I ran this from within the `examples-repository` repo folder, and built the `exarepo_tasks` gem based on a folder in the same super-directory. (Tested alongside images to make sure there were no side effects.)

```{sh}
#!/bin/bash
# Attempts to build dataset collection based on local wax tasks variant

echo "Begin testing! Note you must run this from examples repository root directory."

# Instruct bundler to use local repo in place of wax-tasks
# https://bundler.io/v2.2/guides/git.html#local
# Note: you may have to run bundle install first
bundle config local.wax_tasks ../exarepo_tasks

# Clobber existing wax-generated files for the dataset collection
bundle exec rake wax:clobber datasets
bundle exec rake wax:clobber datavis

# Generate image derivatives
bundle exec rake wax:derivatives:simple datavis

# Generate file derivatives
bundle exec rake wax:file_derivatives:simple datasets

# After clobber, run pages again
bundle exec rake wax:pages datasets
bundle exec rake wax:pages datavis

# Finally, recreate wax search
bundle exec rake wax:search main

# bundle exec rake --tasks
# bundle exec jekyll serve
```

## Future additions

* Support for more data types (.xls, .xlsx, test .zip support)